### PR TITLE
Fix display popup for libreoffice, vscode, and other local programs

### DIFF
--- a/agent_studio/envs/desktop_env/evaluators/os/process_evaluator.py
+++ b/agent_studio/envs/desktop_env/evaluators/os/process_evaluator.py
@@ -67,6 +67,9 @@ class ProcessEvaluator(Evaluator):
             FeedbackException: If the process creation fails.
         """
         logging.info(f"Creating process with command: {cmd}")
+        # IMPORTANT: this needs to be set as below for the process to pop
+        # up in the gui properly!
+        os.environ["DISPLAY"] = ":1"
         try:
             process = subprocess.Popen(cmd)
         except Exception as e:

--- a/eval_online_benchmarks/tasks/single_gui/docs/0810415c-bde4-4443-9047-d5f70165a697.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/0810415c-bde4-4443-9047-d5f70165a697.json
@@ -37,7 +37,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/Novels_Intro_Packet.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/0a0faba3-5580-44df-965d-f562a99b291c.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/0a0faba3-5580-44df-965d-f562a99b291c.json
@@ -41,7 +41,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/04_CHIN9505_EBook_Purchasing_info_2021_Jan.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/0b17a146-2934-46c7-8727-73ff6b6483e8.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/0b17a146-2934-46c7-8727-73ff6b6483e8.json
@@ -46,7 +46,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/H2O_Factsheet_WA.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/0e47de2a-32e0-456c-a366-8c607ef7a9d2.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/0e47de2a-32e0-456c-a366-8c607ef7a9d2.json
@@ -36,7 +36,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/LibreOffice_Open_Source_Word_Processing.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/0e763496-b6bb-4508-a427-fad0b6c3e195.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/0e763496-b6bb-4508-a427-fad0b6c3e195.json
@@ -39,7 +39,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/Dublin_Zoo_Intro.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/3ef2b351-8a84-4ff2-8724-d86eae9b842e.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/3ef2b351-8a84-4ff2-8724-d86eae9b842e.json
@@ -36,7 +36,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/Constitution_Template_With_Guidelines.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/45d61a06-6545-4422-97b7-bc76cfa964c1.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/45d61a06-6545-4422-97b7-bc76cfa964c1.json
@@ -37,7 +37,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/NOVEL_Submission_Guidelines.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/663876c7-3471-43db-ba51-f410b13d9d7d.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/663876c7-3471-43db-ba51-f410b13d9d7d.json
@@ -45,7 +45,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/Factoring_Perfect_Square_Trinomials.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {
@@ -56,7 +56,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/Factoring_Perfect_Square_Trinomials_Gold.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/66399b0d-8fda-4618-95c4-bfc6191617e9.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/66399b0d-8fda-4618-95c4-bfc6191617e9.json
@@ -45,7 +45,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/Table_Of_Work_Effort_Instructions.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/6a33f9b9-0a56-4844-9c3f-96ec3ffb3ba2.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/6a33f9b9-0a56-4844-9c3f-96ec3ffb3ba2.json
@@ -37,7 +37,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/sample-recruitment-phone-script.odt"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/6ada715d-3aae-4a32-a6a7-429b2e43fb93.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/6ada715d-3aae-4a32-a6a7-429b2e43fb93.json
@@ -45,7 +45,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/Viewing_Your_Class_Schedule_and_Textbooks.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/6f81754e-285d-4ce0-b59e-af7edb02d108.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/6f81754e-285d-4ce0-b59e-af7edb02d108.json
@@ -37,7 +37,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/HK_train_record.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/72b810ef-4156-4d09-8f08-a0cf57e7cefe.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/72b810ef-4156-4d09-8f08-a0cf57e7cefe.json
@@ -37,7 +37,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/GEOG2169_Course_Outline_2022-23.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/8472fece-c7dd-4241-8d65-9b3cd1a0b568.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/8472fece-c7dd-4241-8d65-9b3cd1a0b568.json
@@ -37,7 +37,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/Dolch_Sight_Words_Primer.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/docs/88fe4b2d-3040-4c70-9a70-546a47764b48.json
+++ b/eval_online_benchmarks/tasks/single_gui/docs/88fe4b2d-3040-4c70-9a70-546a47764b48.json
@@ -41,7 +41,7 @@
           "libreoffice",
           "${AS_ROOT}/docs/CCCH9003_Tutorial_guidelines.docx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/01b269ae-2111-4a07-81fd-3fcd711993b0.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/01b269ae-2111-4a07-81fd-3fcd711993b0.json
@@ -46,7 +46,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/Student_Level_Fill_Blank.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/0326d92d-d218-48a8-9ca1-981cd6d064c7.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/0326d92d-d218-48a8-9ca1-981cd6d064c7.json
@@ -55,7 +55,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/SalesRep.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/035f41ba-6653-43ab-aa63-c86d449d62e5.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/035f41ba-6653-43ab-aa63-c86d449d62e5.json
@@ -51,7 +51,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/IncomeStatement2.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/04d9aeaf-7bed-4024-bedb-e10e6f00eb7f.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/04d9aeaf-7bed-4024-bedb-e10e6f00eb7f.json
@@ -46,7 +46,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/SmallBalanceSheet.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/0a2e43bf-b26c-4631-a966-af9dfa12c9e5.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/0a2e43bf-b26c-4631-a966-af9dfa12c9e5.json
@@ -54,7 +54,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/SalesRep.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/0acbd372-ca7a-4507-b949-70673120190f.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/0acbd372-ca7a-4507-b949-70673120190f.json
@@ -46,7 +46,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/NetIncome.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/0bf05a7d-b28b-44d2-955a-50b41e24012a.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/0bf05a7d-b28b-44d2-955a-50b41e24012a.json
@@ -63,7 +63,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/Customers_New_7digit_Id.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/42e0a640-4f19-4b28-973d-729602b5a4a7.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/42e0a640-4f19-4b28-973d-729602b5a4a7.json
@@ -46,7 +46,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/NetIncome.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/4e6fcf72-daf3-439f-a232-c434ce416af6.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/4e6fcf72-daf3-439f-a232-c434ce416af6.json
@@ -46,7 +46,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/Employee_Age_By_Birthday.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/8909d1cb-5877-44c7-a908-9f1875302441.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/8909d1cb-5877-44c7-a908-9f1875302441.json
@@ -51,7 +51,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/SummerSales.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/9ed02102-6b28-4946-8339-c028166e9512.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/9ed02102-6b28-4946-8339-c028166e9512.json
@@ -57,7 +57,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/BoomerangSales.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/a16d1eb7-941b-4edd-8c08-344213f939ad.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/a16d1eb7-941b-4edd-8c08-344213f939ad.json
@@ -55,7 +55,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/GDPBreakdown.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/a9f325aa-8c05-4e4f-8341-9e4358565f4f.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/a9f325aa-8c05-4e4f-8341-9e4358565f4f.json
@@ -46,7 +46,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/Movie_titles_garbage_clean.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/b6e9778c-11b3-455f-b720-655048787484.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/b6e9778c-11b3-455f-b720-655048787484.json
@@ -52,7 +52,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/EntireSummerSales.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/sheets/f654bf9a-dea2-472d-a877-edeeb12d7462.json
+++ b/eval_online_benchmarks/tasks/single_gui/sheets/f654bf9a-dea2-472d-a877-edeeb12d7462.json
@@ -52,7 +52,7 @@
           "libreoffice",
           "${AS_ROOT}/sheets/SummerSales.xlsx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/08aced46-45a2-48d7-993b-ed3fb5b32302.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/08aced46-45a2-48d7-993b-ed3fb5b32302.json
@@ -38,7 +38,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/22_6.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/39be0d19-634d-4475-8768-09c130f5425d.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/39be0d19-634d-4475-8768-09c130f5425d.json
@@ -46,7 +46,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/41_3.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/4ed5abd0-8b5d-47bd-839f-cacfa15ca37a.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/4ed5abd0-8b5d-47bd-839f-cacfa15ca37a.json
@@ -38,7 +38,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/4_1.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/7dbc52a6-11e0-4c9a-a2cb-1e36cfda80d8.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/7dbc52a6-11e0-4c9a-a2cb-1e36cfda80d8.json
@@ -38,7 +38,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/164_3.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/986fc832-6af2-417c-8845-9272b3a1528b.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/986fc832-6af2-417c-8845-9272b3a1528b.json
@@ -38,7 +38,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/154_3.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/9ec204e4-f0a3-42f8-8458-b772a6797cab.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/9ec204e4-f0a3-42f8-8458-b772a6797cab.json
@@ -38,7 +38,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/MLA_Workshop_061X_Works_Cited.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/a097acff-6266-4291-9fbd-137af7ecd439.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/a097acff-6266-4291-9fbd-137af7ecd439.json
@@ -40,7 +40,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/Secrets-of-Monetizing-Video.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/a434992a-89df-4577-925c-0c58b747f0f4.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/a434992a-89df-4577-925c-0c58b747f0f4.json
@@ -38,7 +38,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/16_2.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/a669ef01-ded5-4099-9ea9-25e99b569840.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/a669ef01-ded5-4099-9ea9-25e99b569840.json
@@ -40,7 +40,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/Writing-Outlines.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/ac1b39ff-ee4d-4483-abce-c117e98942f0.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/ac1b39ff-ee4d-4483-abce-c117e98942f0.json
@@ -41,7 +41,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/55_10.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/af23762e-2bfd-4a1d-aada-20fa8de9ce07.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/af23762e-2bfd-4a1d-aada-20fa8de9ce07.json
@@ -38,7 +38,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/Forests.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/af2d657a-e6b3-4c6a-9f67-9e3ed015974c.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/af2d657a-e6b3-4c6a-9f67-9e3ed015974c.json
@@ -40,7 +40,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/9_1.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/c82632a4-56b6-4db4-9dd1-3820ee3388e4.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/c82632a4-56b6-4db4-9dd1-3820ee3388e4.json
@@ -49,7 +49,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/31_2.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/e4ef0baf-4b52-4590-a47e-d4d464cca2d7.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/e4ef0baf-4b52-4590-a47e-d4d464cca2d7.json
@@ -38,7 +38,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/42_2.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {

--- a/eval_online_benchmarks/tasks/single_gui/slides/ed43c15f-00cb-4054-9c95-62c880865d68.json
+++ b/eval_online_benchmarks/tasks/single_gui/slides/ed43c15f-00cb-4054-9c95-62c880865d68.json
@@ -41,7 +41,7 @@
           "libreoffice",
           "${AS_ROOT}/slides/43_1.pptx"
         ],
-        "wait_for": "libreoffice"
+        "wait_for": "soffice"
       }
     },
     {


### PR DESCRIPTION
This fixes the issue whereby visual programs (libreoffice calc, etc.) were not popping up properly in new tasks. This had to do with the `:DISPLAY` variable being set within the python environment incorrectly. Additionally, the name of the `libreoffice` program was incorrect and needed to be changed to `soffice`.

Verified locally and on cluster!